### PR TITLE
introduce VNC_PASSWORDLESS

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ The following VNC environment variables can be overwritten at the `docker run` p
 * `VNC_COL_DEPTH`, default: `24`
 * `VNC_RESOLUTION`, default: `1280x1024`
 * `VNC_PW`, default: `my-pw`
+* `VNC_PASSWORDLESS`, default: `<not set>`
 
 #### 3.1) Example: Override the VNC password
 Simply overwrite the value of the environment variable `VNC_PW`. For example in
@@ -124,6 +125,13 @@ the docker run command:
 
     docker run -it -p 5901:5901 -p 6901:6901 -e VNC_RESOLUTION=800x600 consol/centos-xfce-vnc
     
+#### 3.3) Example: Start passwordless
+Set `VNC_PASSWORDLESS` to `true` to disable the VNC password.
+It is highly recommended that you put some kind of authorization mechanism
+before this. For example in the docker run command:
+
+    docker run -it -p 5901:5901 -p 6901:6901 -e VNC_PASSWORDLESS=true consol/centos-xfce-vnc
+
 ### 4) View only VNC
 Since version `1.2.0` it's possible to prevent unwanted control via VNC. Therefore you can set the environment variable `VNC_VIEW_ONLY=true`. If set, the startup script will create a random password for the control connection and use the value of `VNC_PW` for view only connection over the VNC connection.
 

--- a/src/common/scripts/vnc_startup.sh
+++ b/src/common/scripts/vnc_startup.sh
@@ -95,8 +95,14 @@ vncserver -kill $DISPLAY &> $STARTUPDIR/vnc_startup.log \
     || echo "no locks present"
 
 echo -e "start vncserver with param: VNC_COL_DEPTH=$VNC_COL_DEPTH, VNC_RESOLUTION=$VNC_RESOLUTION\n..."
-if [[ $DEBUG == true ]]; then echo "vncserver $DISPLAY -depth $VNC_COL_DEPTH -geometry $VNC_RESOLUTION"; fi
-vncserver $DISPLAY -depth $VNC_COL_DEPTH -geometry $VNC_RESOLUTION &> $STARTUPDIR/no_vnc_startup.log
+vnc_cmd="vncserver $DISPLAY -depth $VNC_COL_DEPTH -geometry $VNC_RESOLUTION"
+
+if [[ ${VNC_PASSWORDLESS:-} == "true" ]]; then
+  vnc_cmd="${vnc_cmd} -SecurityTypes None"
+fi
+
+if [[ $DEBUG == true ]]; then echo "$vnc_cmd"; fi
+$vnc_cmd &> $STARTUPDIR/no_vnc_startup.log
 echo -e "start window manager\n..."
 $HOME/wm_startup.sh &> $STARTUPDIR/wm_startup.log
 


### PR DESCRIPTION
Hi!

This introduces the environment variable `VNC_PASSWORDLESS` to disable the VNC password.

Our use-case is simple: we have a reverse proxy in place that does authentication and authorization already, so having to supply a password (or append it to the URL) is just bad UX for us.

It would be great if you accepted this.

I only tested this locally with ubuntu.xfce, e.g.
```
docker build -t vnc -f Dockerfile.ubuntu.xfce.vnc .
docker run -e VNC_PASSWORDLESS=true -p 5901:5901 -p 6901:6901 vnc
```

Thanks for creating this container! :)

Best,
  Felix