### PR TITLE
Add aarch64 support

### DIFF
--- a/src/common/scripts/generate_container_user
+++ b/src/common/scripts/generate_container_user
@@ -21,6 +21,8 @@ if [ x"$USER_ID" != x"0" ]; then
         LD_PRELOAD=/usr/lib64/libnss_wrapper.so
     elif [ -r /usr/lib/x86_64-linux-gnu/libnss_wrapper.so ]; then
         LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libnss_wrapper.so
+    elif [ -r /usr/lib/aarch64-linux-gnu/libnss_wrapper.so ]; then
+        LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libnss_wrapper.so
     else
         echo "no libnss_wrapper.so installed!"
         exit 1


### PR DESCRIPTION
Added path for libnss_wrapper.so on aarch64 architecture, now the container works fine on arm64 based linux machines