### PR TITLE
Update releases.yml

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -59,6 +59,7 @@ jobs:
           push: true
           file: Dockerfile.${{ matrix.target }}
           tags: consol/${{ matrix.target }}:${{ env.BRANCH_NAME }}, consol/${{ matrix.target }}:latest
+          platforms: linux/amd64,linux/arm64
       - name: Build container image
         uses: docker/build-push-action@v4
         with:


### PR DESCRIPTION

If you look here: https://docs.docker.com/build/ci/github-actions/multi-platform/

There is a flag to allow for multi-platform build support. This probably also needs get put into the nightly ... I'll make a separate PR because I'm working off github