### PR TITLE
Update nightly.yml for multi-platform builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -58,6 +58,7 @@ jobs:
           push: true
           file: Dockerfile.${{ matrix.target }}
           tags: consol/${{ matrix.target }}:nightly
+          platforms: linux/amd64,linux/arm64
       - name: Build container image
         uses: docker/build-push-action@v4
         with:


### PR DESCRIPTION
Similar to the PR in #177 - there is a flag to allow for multi-platform builds. This will help out the Arm64 folks