### PR TITLE
fix: passwordless startup crash

### DIFF
--- a/src/common/scripts/vnc_startup.sh
+++ b/src/common/scripts/vnc_startup.sh
@@ -99,7 +99,7 @@ echo -e "start vncserver with param: VNC_COL_DEPTH=$VNC_COL_DEPTH, VNC_RESOLUTIO
 
 vnc_cmd="vncserver $DISPLAY -depth $VNC_COL_DEPTH -geometry $VNC_RESOLUTION PasswordFile=$HOME/.vnc/passwd"
 if [[ ${VNC_PASSWORDLESS:-} == "true" ]]; then
-  vnc_cmd="${vnc_cmd} -SecurityTypes None"
+  vnc_cmd="${vnc_cmd} -SecurityTypes None --I-KNOW-THIS-IS-INSECURE"
 fi
 
 if [[ $DEBUG == true ]]; then echo "$vnc_cmd"; fi


### PR DESCRIPTION
This is a PR to fix #192.
This fixes the startup of the Container if passwordless is true.